### PR TITLE
Move export to normal export instead of typed export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@propelauth/node-apis",
-    "version": "2.1.12",
+    "version": "2.1.13",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@propelauth/node-apis",
-            "version": "2.1.12",
+            "version": "2.1.13",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/PropelAuth/node-apis"
     },
-    "version": "2.1.12",
+    "version": "2.1.13",
     "license": "MIT",
     "keywords": [
         "auth",

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,8 +66,7 @@ export type {
     OrgApiKeyValidation,
     InternalUser,
     InternalOrgMemberInfo,
-    OrgRoleStructure,
 } from "./user"
-export { UserClass, OrgMemberInfo, toUser, toOrgIdToOrgMemberInfo } from "./user"
+export { UserClass, OrgMemberInfo, OrgRoleStructure, toUser, toOrgIdToOrgMemberInfo } from "./user"
 export { getApis } from "./api"
 export { parseSnakeCaseToCamelCase } from "./utils"


### PR DESCRIPTION
When using this in another library, it was reading as undefined -- an enum needs to be exported outside of the `export type` declaration.