### PR TITLE
[TIC-878] Resend email confirmation

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -20,6 +20,7 @@ import {
     disableUser2fa,
     disableUserCanCreateOrgs,
     enableUser,
+    resendEmailConfirmation,
     enableUserCanCreateOrgs,
     fetchBatchUserMetadata,
     fetchUserMetadataByQuery,
@@ -193,6 +194,10 @@ export function getApis(authUrl: URL, integrationApiKey: string) {
         return disableUser2fa(authUrl, integrationApiKey, userId)
     }
 
+    function resendEmailConfirmationWrapper(userId: string): Promise<boolean> {
+        return resendEmailConfirmation(authUrl, integrationApiKey, userId)
+    }
+
     function updateUserEmailWrapper(userId: string, updateUserEmailRequest: UpdateUserEmailRequest): Promise<boolean> {
         return updateUserEmail(authUrl, integrationApiKey, userId, updateUserEmailRequest)
     }
@@ -327,6 +332,7 @@ export function getApis(authUrl: URL, integrationApiKey: string) {
         disableUser: disableUserWrapper,
         enableUser: enableUserWrapper,
         disableUser2fa: disableUser2faWrapper,
+        resendEmailConfirmation: resendEmailConfirmationWrapper,
         enableUserCanCreateOrgs: enableUserCanCreateOrgsWrapper,
         disableUserCanCreateOrgs: disableUserCanCreateOrgsWrapper,
         // org management functions

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -288,7 +288,7 @@ export function resendEmailConfirmation(authUrl: URL, integrationApiKey: string,
     return httpRequest(
         authUrl,
         integrationApiKey,
-        `/api/backend/v1/resend_email_confirmation`,
+        "/api/backend/v1/resend_email_confirmation",
         "POST",
         JSON.stringify(request)
     ).then((httpResponse) => {

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -276,6 +276,38 @@ export function disableUser2fa(authUrl: URL, integrationApiKey: string, userId: 
     )
 }
 
+export function resendEmailConfirmation(authUrl: URL, integrationApiKey: string, userId: string): Promise<boolean> {
+    if (!isValidId(userId)) {
+        return Promise.resolve(false)
+    }
+
+    const request = {
+        user_id: userId,
+    }
+
+    return httpRequest(
+        authUrl,
+        integrationApiKey,
+        `/api/backend/v1/resend_email_confirmation`,
+        "POST",
+        JSON.stringify(request)
+    ).then((httpResponse) => {
+        if (httpResponse.statusCode === 401) {
+            throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 404) {
+            return false
+        } else if (httpResponse.statusCode === 429) {
+            throw new Error("Rate limited when resending email confirmation")
+        } else if (httpResponse.statusCode === 400) {
+            throw new BadRequestException(httpResponse.response)
+        } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
+            throw new Error("Unknown error when resending email confirmation")
+        }
+
+        return true
+    })
+}
+
 export type InviteUserToOrgRequest = {
     orgId: string
     email: string


### PR DESCRIPTION
# Background

A new request has been added -- `resendEmailConfirmation`. This will allow a user to resend an email confirmation for a created, unconfirmed user. 

## Usage
Here is a basic example usage of this request:
```ts
const {
  resendEmailConfirmation,
} = propelAuth.initBaseAuth({
  authUrl: AUTH_URL,
  apiKey: API_KEY,
});

resendEmailConfirmation("<User ID>").then((res) => {
	if (res) {
		console.log("Resent successfully");
	} else {
		console.log("Error resending");
	}
}).catch(...);
```