### PR TITLE
[TIC-902] Add `picture_url` to `migrateUserFromExternalSource` request

### DIFF
--- a/src/api/migrateUser.ts
+++ b/src/api/migrateUser.ts
@@ -20,6 +20,7 @@ export type MigrateUserFromExternalSourceRequest = {
     firstName?: string
     lastName?: string
     username?: string
+    pictureUrl?: string
     properties?: { [key: string]: any }
 }
 
@@ -28,21 +29,36 @@ export function migrateUserFromExternalSource(
     integrationApiKey: string,
     migrateUserFromExternalSourceRequest: MigrateUserFromExternalSourceRequest
 ): Promise<CreatedUser> {
+    const {
+        email,
+        emailConfirmed: email_confirmed,
+        existingUserId: existing_user_id,
+        existingPasswordHash: existing_password_hash,
+        existingMfaBase32EncodedSecret: existing_mfa_base32_encoded_secret,
+        askUserToUpdatePasswordOnLogin: update_password_required,
+        enabled,
+        firstName: first_name,
+        lastName: last_name,
+        username,
+        pictureUrl: picture_url,
+        properties,
+    } = migrateUserFromExternalSourceRequest
     const request = {
-        email: migrateUserFromExternalSourceRequest.email,
-        email_confirmed: migrateUserFromExternalSourceRequest.emailConfirmed,
+        email,
+        email_confirmed,
 
-        existing_user_id: migrateUserFromExternalSourceRequest.existingUserId,
-        existing_password_hash: migrateUserFromExternalSourceRequest.existingPasswordHash,
-        existing_mfa_base32_encoded_secret: migrateUserFromExternalSourceRequest.existingMfaBase32EncodedSecret,
-        update_password_required: migrateUserFromExternalSourceRequest.askUserToUpdatePasswordOnLogin,
+        existing_user_id,
+        existing_password_hash,
+        existing_mfa_base32_encoded_secret,
+        update_password_required,
 
-        enabled: migrateUserFromExternalSourceRequest.enabled,
+        enabled,
 
-        first_name: migrateUserFromExternalSourceRequest.firstName,
-        last_name: migrateUserFromExternalSourceRequest.lastName,
-        username: migrateUserFromExternalSourceRequest.username,
-        properties: migrateUserFromExternalSourceRequest.properties,
+        first_name,
+        last_name,
+        username,
+        picture_url,
+        properties,
     }
     return httpRequest(authUrl, integrationApiKey, `${ENDPOINT_PATH}/`, "POST", JSON.stringify(request)).then(
         (httpResponse) => {


### PR DESCRIPTION
# Background
The `picture_url` request parameter was missing from the library. It has now been added as an optional value. 

## Usage

Here is an example usage: 

```js
const propelAuth = require("@propelauth/node");
const {
  migrateUserFromExternalSource,
} = propelAuth.initBaseAuth({
  authUrl: AUTH_URL,
  apiKey: API_KEY,
});
const migrateRequest = {
      email: "test@example.com",
      emailConfirmed: true,
      enabled: true,
      username: "test",
      firstName: "Test",
      lastName: "User",
      pictureUrl: "https://placekitten.com/200/300",
    };
};
const newUserId = migrateUserFromExternalSource(migrateRequest).then((response) => {
	console.log(`Created new user with User ID ${response.userId}`);
}).catch(...);
```