### PR TITLE
[TIC-904] Fetch pending invites

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -55,8 +55,11 @@ import {
     fetchCustomRoleMappings,
     fetchOrg,
     fetchOrgByQuery,
+    fetchPendingInvites,
+    FetchPendingInvitesParams,
     OrgQuery,
     OrgQueryResponse,
+    PendingInvitesPage,
     removeUserFromOrg,
     RemoveUserFromOrgRequest,
     subscribeOrgToRoleMapping,
@@ -283,6 +286,10 @@ export function getApis(authUrl: URL, integrationApiKey: string) {
         return logoutAllUserSessions(authUrl, integrationApiKey, userId)
     }
 
+    function fetchPendingInvitesWrapper(params: FetchPendingInvitesParams): Promise<PendingInvitesPage> {
+        return fetchPendingInvites(authUrl, integrationApiKey, params)
+    }
+
     // end user api key wrappers
     function fetchApiKeyWrapper(apiKeyId: string): Promise<ApiKeyFull> {
         return fetchApiKey(authUrl, integrationApiKey, apiKeyId)
@@ -364,6 +371,7 @@ export function getApis(authUrl: URL, integrationApiKey: string) {
         allowOrgToSetupSamlConnection: allowOrgToSetupSamlConnectionWrapper,
         disallowOrgToSetupSamlConnection: disallowOrgToSetupSamlConnectionWrapper,
         inviteUserToOrg: inviteUserToOrgWrapper,
+        fetchPendingInvites: fetchPendingInvitesWrapper,
         // api keys functions
         fetchApiKey: fetchApiKeyWrapper,
         fetchCurrentApiKeys: fetchCurrentApiKeysWrapper,

--- a/src/api.ts
+++ b/src/api.ts
@@ -286,7 +286,7 @@ export function getApis(authUrl: URL, integrationApiKey: string) {
         return logoutAllUserSessions(authUrl, integrationApiKey, userId)
     }
 
-    function fetchPendingInvitesWrapper(params: FetchPendingInvitesParams): Promise<PendingInvitesPage> {
+    function fetchPendingInvitesWrapper(params?: FetchPendingInvitesParams): Promise<PendingInvitesPage> {
         return fetchPendingInvites(authUrl, integrationApiKey, params)
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,9 @@ export type {
     ChangeUserRoleInOrgRequest,
     RemoveUserFromOrgRequest,
     UpdateOrgRequest,
+    FetchPendingInvitesParams,
+    PendingInvitesPage,
+    PendingInvite,
 } from "./api/org"
 export type { TokenVerificationMetadata } from "./api/tokenVerificationMetadata"
 export type {

--- a/test/conversion.ts
+++ b/test/conversion.ts
@@ -41,6 +41,45 @@ test("parseSnakeCaseToCamelCase converts correctly", async () => {
     }
 
     expect(parseSnakeCaseToCamelCase(JSON.stringify(snakeCase))).toEqual(camelCase)
+
+    const snakeCaseJson = {
+        first_name: "John",
+        last_name: "Doe",
+        contact_info: {
+            email_address: "john.doe@example.com",
+            phone_number: "123-456-7890",
+        },
+        hobbies: [
+            {
+                hobby_name: "Reading",
+                hobby_level: "Intermediate",
+            },
+            {
+                hobby_name: "Swimming",
+                hobby_level: "Advanced",
+            },
+        ],
+    }
+    const camelCaseJson = {
+        firstName: "John",
+        lastName: "Doe",
+        contactInfo: {
+            emailAddress: "john.doe@example.com",
+            phoneNumber: "123-456-7890",
+        },
+        hobbies: [
+            {
+                hobbyName: "Reading",
+                hobbyLevel: "Intermediate",
+            },
+            {
+                hobbyName: "Swimming",
+                hobbyLevel: "Advanced",
+            },
+        ],
+    }
+
+    expect(parseSnakeCaseToCamelCase(JSON.stringify(snakeCaseJson))).toEqual(camelCaseJson)
 })
 
 test("parseSnakeCaseToCamelCase adds functions to orgMemberInfo", async () => {


### PR DESCRIPTION
# Background
A new request has been added, `fetchPendingInvites`, that let's one fetch the pending org invites, which can be filtered by org ID.

## Example Usage
```js
const propelAuth = require("@propelauth/node");
const auth = propelAuth.initBaseAuth({
  authUrl: AUTH_URL,
  apiKey: API_KEY,
});
const response = await auth.fetchPendingInvites({
	orgId: "<ORG ID>",
}).then((response) => {
	console.log("Paginated pending invites", response);
}).catch(...);
```