### PR TITLE
update legacy_org_id, fetch by legacy user/org ids, and patch bump to 2.1.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@propelauth/node-apis",
-    "version": "2.1.20",
+    "version": "2.1.22",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@propelauth/node-apis",
-            "version": "2.1.20",
+            "version": "2.1.22",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/PropelAuth/node-apis"
     },
-    "version": "2.1.21",
+    "version": "2.1.22",
     "license": "MIT",
     "keywords": [
         "auth",

--- a/src/api/org.ts
+++ b/src/api/org.ts
@@ -113,6 +113,7 @@ export type OrgQuery = {
     pageNumber?: number
     orderBy?: "CREATED_AT_ASC" | "CREATED_AT_DESC" | "NAME"
     name?: string
+    legacyOrgId?: string
 }
 
 export type OrgQueryResponse = {
@@ -129,6 +130,7 @@ export function fetchOrgByQuery(authUrl: URL, integrationApiKey: string, query: 
         page_number: query.pageNumber,
         order_by: query.orderBy,
         name: query.name,
+        legacy_org_id: query.legacyOrgId,
     }
     return httpRequest(authUrl, integrationApiKey, `${ENDPOINT_PATH}/query`, "POST", JSON.stringify(request)).then(
         (httpResponse) => {
@@ -402,6 +404,7 @@ export type UpdateOrgRequest = {
     canJoinOnEmailDomainMatch?: boolean // In the backend, this is the `domain_autojoin` argument.
     membersMustHaveEmailDomainMatch?: boolean // In the backend, this is the `domain_restrict` argument.
     domain?: string
+    legacyOrgId?: string
     // TODO: Add `require_2fa_by` optional argument.
 }
 
@@ -422,6 +425,7 @@ export function updateOrg(
         autojoin_by_domain: updateOrgRequest.canJoinOnEmailDomainMatch,
         restrict_to_domain: updateOrgRequest.membersMustHaveEmailDomainMatch,
         domain: updateOrgRequest.domain,
+        legacy_org_id: updateOrgRequest.legacyOrgId,
     }
     return httpRequest(
         authUrl,

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -17,6 +17,7 @@ export type UsersQuery = {
     orderBy?: "CREATED_AT_ASC" | "CREATED_AT_DESC" | "LAST_ACTIVE_AT_ASC" | "LAST_ACTIVE_AT_DESC" | "EMAIL" | "USERNAME"
     emailOrUsername?: string
     includeOrgs?: boolean
+    legacyUserId?: string
 }
 
 export type UsersPagedResponse = {
@@ -82,6 +83,7 @@ export function fetchUsersByQuery(
         order_by: query.orderBy,
         email_or_username: query.emailOrUsername,
         include_orgs: query.includeOrgs,
+        legacy_user_id: query.legacyUserId,
     }
     const q = formatQueryParameters(queryParams)
     return httpRequest(authUrl, integrationApiKey, `${ENDPOINT_PATH}/query?${q}`, "GET").then((httpResponse) => {


### PR DESCRIPTION
[Context](https://www.notion.so/Add-a-legacy-org-ID-542f0ad4647041a3849459e8d352b89c?pvs=4)
[BE PR](https://github.com/PropelAuth/auth/pull/787)

## After PR
1. update org's legacy_org_id
```javascript
auth.updateOrg({
    orgId: "1189c444-8a2d-4c41-8b4b-ae43ce79a492",
    legacyOrgId: "<LEGACY_ID>",
})
```
2. fetch/search orgs on the legacy id (case-sensitive string)
```javascript
auth.fetchOrgByQuery({
    legacyUserId: "<LEGACY_ID>",
})
```
3. fetch/search users on the legacy id (case-sensitive string)
```javascript
auth.fetchUsersByQuery({
    legacyOrgId: "<LEGACY_ID>",
})
```
