### PR TITLE
support configuration of saml connection configuration for an org

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -24,12 +24,15 @@ import {
     createOrgSamlConnectionLink,
     CreateSamlConnectionLinkResponse,
     deleteOrg,
+    deleteSamlConnection,
     disallowOrgToSetupSamlConnection,
     fetchCustomRoleMappings,
     fetchOrg,
     fetchOrgByQuery,
     fetchPendingInvites,
     FetchPendingInvitesParams,
+    fetchSamlSpMetadata,
+    FetchSamlSpMetadataResponse,
     OrgQuery,
     OrgQueryResponse,
     PendingInvitesPage,
@@ -37,6 +40,9 @@ import {
     RemoveUserFromOrgRequest,
     revokePendingOrgInvite,
     RevokePendingOrgInviteRequest,
+    samlGoLive,
+    setSamlIdpMetadata,
+    SetSamlIdpMetadataRequest,
     subscribeOrgToRoleMapping,
     updateOrg,
     UpdateOrgRequest,
@@ -288,6 +294,29 @@ export function getApis(authUrl: URL, integrationApiKey: string) {
         return createOrgSamlConnectionLink(authUrl, integrationApiKey, orgId, expiresInSeconds)
     }
 
+    function fetchSamlSpMetadataWrapper(
+        orgId: string,
+    ): Promise<FetchSamlSpMetadataResponse> {
+        return fetchSamlSpMetadata(authUrl, integrationApiKey, orgId)
+    }
+
+    function setSamlIdpMetadataWrapper(
+        orgId: string,
+        samlIdpMetadata: SetSamlIdpMetadataRequest,
+    ): Promise<boolean> {
+        return setSamlIdpMetadata(authUrl, integrationApiKey, samlIdpMetadata)
+    }
+
+    function samlGoLiveWrapper(
+        orgId: string,
+    ): Promise<boolean> {
+        return samlGoLive(authUrl, integrationApiKey, orgId)
+    }
+
+    function deleteSamlConnectionWrapper(orgId: string): Promise<boolean> {
+        return deleteSamlConnection(authUrl, integrationApiKey, orgId)
+    }
+
     function inviteUserToOrgWrapper(inviteUserToOrgRequest: InviteUserToOrgRequest): Promise<boolean> {
         return inviteUserToOrg(authUrl, integrationApiKey, inviteUserToOrgRequest)
     }
@@ -390,6 +419,10 @@ export function getApis(authUrl: URL, integrationApiKey: string) {
         inviteUserToOrg: inviteUserToOrgWrapper,
         fetchPendingInvites: fetchPendingInvitesWrapper,
         revokePendingOrgInvite: revokePendingOrgInviteWrapper,
+        fetchSamlSpMetadata: fetchSamlSpMetadataWrapper,
+        setSamlIdpMetadata: setSamlIdpMetadataWrapper,
+        samlGoLive: samlGoLiveWrapper,
+        deleteSamlConnection: deleteSamlConnectionWrapper,
         // api keys functions
         fetchApiKey: fetchApiKeyWrapper,
         fetchCurrentApiKeys: fetchCurrentApiKeysWrapper,

--- a/src/api.ts
+++ b/src/api.ts
@@ -304,7 +304,7 @@ export function getApis(authUrl: URL, integrationApiKey: string) {
         orgId: string,
         samlIdpMetadata: SetSamlIdpMetadataRequest,
     ): Promise<boolean> {
-        return setSamlIdpMetadata(authUrl, integrationApiKey, samlIdpMetadata)
+        return setSamlIdpMetadata(authUrl, integrationApiKey, orgId, samlIdpMetadata)
     }
 
     function samlGoLiveWrapper(

--- a/src/api/org.ts
+++ b/src/api/org.ts
@@ -460,7 +460,6 @@ export async function createOrgSamlConnectionLink(
 }
 
 export type SetSamlIdpMetadataRequest = {
-    orgId: string
     idpEntityId: string
     idpSsoUrl: string
     idpCertificate: string
@@ -472,18 +471,27 @@ export type IdpProvider = "Google" | "Rippling" | "OneLogin" | "JumpCloud" | "Ok
 export function setSamlIdpMetadata(
     authUrl: URL,
     integrationApiKey: string,
+    orgId: string,
     setSamlIdpMetadataRequest: SetSamlIdpMetadataRequest
 ): Promise<boolean> {
-    if (!isValidId(setSamlIdpMetadataRequest.orgId)) {
+    if (!isValidId(orgId)) {
         return Promise.resolve(false)
     }
+
+    let request = {
+        org_id: orgId,
+        idp_entity_id: setSamlIdpMetadataRequest.idpEntityId,
+        idp_sso_url: setSamlIdpMetadataRequest.idpSsoUrl,
+        idp_certificate: setSamlIdpMetadataRequest.idpCertificate,
+        provider: setSamlIdpMetadataRequest.provider,
+    };
 
     return httpRequest(
         authUrl,
         integrationApiKey,
         `${BASE_ENDPOINT_PATH}/saml_idp_metadata`,
         "POST",
-        JSON.stringify(setSamlIdpMetadataRequest)
+        JSON.stringify(request)
     ).then(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {


### PR DESCRIPTION
depends on [BE PR](https://github.com/PropelAuth/auth/pull/844)

## After PR
Here's a naive example of what you can do now
```javascript
let org = await auth.fetchOrg(orgId);

if (!org.isSamlConfigured) {
    console.log("Org does not have SAML configured. Setting up SAML...");

    auth.updateOrg({
        orgId,
        canSetupSaml: true,
    })

    let spMetadata = await auth.fetchSamlSpMetadata(orgId);
    console.log(`SP Metadata: %s`, spMetadata);

    // example response...
    `
    FetchSamlSpMetadataResponse {
        entityId: 'https://auth.your.domain/saml/ORGS-URL-SLUG/metadata',
        acsUrl: 'https://auth.your.domain/saml/ORGS-URL-SLUG/acs',
        logoutUrl: 'https://auth.your.domain/saml/ORGS-URL-SLUG/logout'
    }
    `

    // NOT IMPLEMENTED: Upsert this SP metadata to the IdP
    // NOT IMPLEMENTED: Get the metadata needed from the IdP

    await auth.setSamlIdpMetadata(orgId, {
        idpEntityId: "https://sts.windows.net/SOME-UUID/",
        idpSsoUrl: "https://login.microsoftonline.com/SOME-UUID/saml2",
        idpCertificate: `-----BEGIN CERTIFICATE-----
MyCertificateHere
-----END CERTIFICATE-----`,
        provider: 'Azure',
    });

    await auth.samlGoLive(orgId);

} else {
    console.log("Org already has SAML configured. Deleting the connection...");

    await auth.deleteSamlConnection(orgId);
}
```

## Tests
Built a modified version of the above proof-of-concept within an example app.