### PR TITLE
handle ApiKeyValidateRateLimitedException

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/PropelAuth/node-apis"
     },
-    "version": "2.1.26",
+    "version": "2.1.27",
     "license": "MIT",
     "keywords": [
         "auth",

--- a/src/api/endUserApiKeys.ts
+++ b/src/api/endUserApiKeys.ts
@@ -4,6 +4,7 @@ import {
     ApiKeyFetchException,
     ApiKeyUpdateException,
     ApiKeyValidateException,
+    ApiKeyValidateRateLimitedException,
 } from "../exceptions"
 import { httpRequest } from "../http"
 import { ApiKeyFull, ApiKeyNew, ApiKeyResultPage, ApiKeyValidation } from "../user"
@@ -144,6 +145,8 @@ export function validateApiKey(
                 throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyValidateException(httpResponse.response)
+            } else if (httpResponse.statusCode === 429) {
+                throw new ApiKeyValidateRateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
                 throw new Error("Unknown error when updating the end user api key")
             }

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -143,6 +143,19 @@ export class ApiKeyValidateException extends Error {
     }
 }
 
+export class ApiKeyValidateRateLimitedException extends Error {
+    readonly waitSeconds: number;
+    readonly userFacingError: string;
+    readonly errorCode: string;
+    constructor(errorBody: string) {
+        super(errorBody);
+        const parsedErrorBody = JSON.parse(errorBody);
+        this.waitSeconds = parsedErrorBody.wait_seconds;
+        this.userFacingError = parsedErrorBody.user_facing_error;
+        this.errorCode = parsedErrorBody.error_code;
+    }
+}
+
 export class ApiKeyDeleteException extends Error {
     readonly fieldToErrors: {[fieldName: string]: string[]};
     constructor(message: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export type { MigrateUserFromExternalSourceRequest } from "./api/migrateUser"
 export type { ApiKeysQueryRequest, ApiKeysCreateRequest, ApiKeyUpdateRequest } from "./api/endUserApiKeys"
 export {
     ApiKeyValidateException,
+    ApiKeyValidateRateLimitedException,
     ApiKeyDeleteException,
     ApiKeyUpdateException,
     ApiKeyCreateException,


### PR DESCRIPTION
## After PR
Introduces `ApiKeyValidateRateLimitedException` error for rate limiting end-user api keys. This includes the fields `waitSeconds` (decimal of seconds until a key/user/org is no longer rate limited), `userFacingError`, `errorCode` (always `rate_limit_exceeded` for this case).

Example use once `ApiKeyValidateRateLimitedException` is passed through the node repo:
```node

// Endpoint that returns user's information
app.get('/check_key', async (req, res) => {
    const authorizationHeader = req.get('Authorization');
    try {
        const inputKey = authorizationHeader.split(' ')[1];
        const validation = await auth.validateApiKey(inputKey);
        res.json(validation);
    } catch (err) {
        if (err instanceof ApiKeyValidateRateLimitedException) {
            res.status(429).send(`{"error": "Rate limited for ${err.waitSeconds} seconds"}`);
        } else if (err instanceof ApiKeyValidateException) {
            res.status(401).send(`{"error": "Invalid key"}`);
        } else {
            res.status(500).send(`{"error": "Internal server error"}`);
        }
    }
});
```

## Tests
Using yalc and publishing to a local repo of the `node ` library, I verified the expected behavior in an example app that validates api keys
