### PR TITLE
catch PropelAuth rate limits as RateLimitedException

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/PropelAuth/node-apis"
     },
-    "version": "2.2.0",
+    "version": "2.1.29",
     "license": "MIT",
     "keywords": [
         "auth",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/PropelAuth/node-apis"
     },
-    "version": "2.1.28",
+    "version": "2.2.0",
     "license": "MIT",
     "keywords": [
         "auth",

--- a/src/api/accessToken.ts
+++ b/src/api/accessToken.ts
@@ -1,4 +1,4 @@
-import { AccessTokenCreationException, UserNotFoundException } from "../exceptions"
+import { AccessTokenCreationException, RateLimitedException, UserNotFoundException } from "../exceptions"
 import { httpRequest } from "../http"
 import { isValidId } from "../utils"
 
@@ -31,6 +31,8 @@ export function createAccessToken(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 400) {
                 throw new AccessTokenCreationException(httpResponse.response)
             } else if (httpResponse.statusCode === 403) {

--- a/src/api/endUserApiKeys.ts
+++ b/src/api/endUserApiKeys.ts
@@ -155,10 +155,10 @@ export function validateApiKey(
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyValidateException(httpResponse.response)
             } else if (httpResponse.statusCode === 429) {
-                const rateLimitError = new ApiKeyValidateRateLimitedException(httpResponse.response);
-                // if specefic fields like "error_code" can't be parsed from the response,
-                // it means the this is a PropelAuth rate limit error
-                if (!rateLimitError.errorCode) {
+                let rateLimitError: ApiKeyValidateRateLimitedException;
+                try {
+                    rateLimitError = new ApiKeyValidateRateLimitedException(httpResponse.response);
+                } catch (SyntaxError) {
                     throw new RateLimitedException(httpResponse.response);
                 }
                 throw rateLimitError;

--- a/src/api/endUserApiKeys.ts
+++ b/src/api/endUserApiKeys.ts
@@ -5,6 +5,7 @@ import {
     ApiKeyUpdateException,
     ApiKeyValidateException,
     ApiKeyValidateRateLimitedException,
+    RateLimitedException,
 } from "../exceptions"
 import { httpRequest } from "../http"
 import { ApiKeyFull, ApiKeyNew, ApiKeyResultPage, ApiKeyValidation } from "../user"
@@ -21,6 +22,8 @@ export function fetchApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: s
     return httpRequest(authUrl, integrationApiKey, `${ENDPOINT_PATH}/${apiKeyId}`, "GET").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 400) {
             throw new ApiKeyFetchException(httpResponse.response)
         } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -56,6 +59,8 @@ export function fetchCurrentApiKeys(
     return httpRequest(authUrl, integrationApiKey, `${ENDPOINT_PATH}?${queryString}`, "GET").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 400) {
             throw new ApiKeyFetchException(httpResponse.response)
         } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -84,6 +89,8 @@ export function fetchArchivedApiKeys(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyFetchException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -119,6 +126,8 @@ export function createApiKey(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyCreateException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -146,7 +155,13 @@ export function validateApiKey(
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyValidateException(httpResponse.response)
             } else if (httpResponse.statusCode === 429) {
-                throw new ApiKeyValidateRateLimitedException(httpResponse.response)
+                const rateLimitError = new ApiKeyValidateRateLimitedException(httpResponse.response);
+                // if specefic fields like "error_code" can't be parsed from the response,
+                // it means the this is a PropelAuth rate limit error
+                if (!rateLimitError.errorCode) {
+                    throw new RateLimitedException(httpResponse.response);
+                }
+                throw rateLimitError;
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
                 throw new Error("Unknown error when updating the end user api key")
             }
@@ -186,6 +201,8 @@ export function updateApiKey(
     ).then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 400) {
             throw new ApiKeyUpdateException(httpResponse.response)
         } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -205,6 +222,8 @@ export function deleteApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: 
     return httpRequest(authUrl, integrationApiKey, `${ENDPOINT_PATH}/${apiKeyId}`, "DELETE").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 400) {
             throw new ApiKeyDeleteException(httpResponse.response)
         } else if (httpResponse.statusCode === 404) {

--- a/src/api/magicLink.ts
+++ b/src/api/magicLink.ts
@@ -1,4 +1,4 @@
-import { MagicLinkCreationException } from "../exceptions"
+import { MagicLinkCreationException, RateLimitedException } from "../exceptions"
 import { httpRequest } from "../http"
 
 const ENDPOINT_PATH = "/api/backend/v1/magic_link"
@@ -30,6 +30,8 @@ export function createMagicLink(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 400) {
                 throw new MagicLinkCreationException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {

--- a/src/api/migrateUser.ts
+++ b/src/api/migrateUser.ts
@@ -1,4 +1,4 @@
-import { MigrateUserException } from "../exceptions"
+import { MigrateUserException, RateLimitedException } from "../exceptions"
 import { httpRequest } from "../http"
 import { CreatedUser } from "../user"
 import { parseSnakeCaseToCamelCase } from "../utils"
@@ -64,6 +64,8 @@ export function migrateUserFromExternalSource(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 400) {
                 throw new MigrateUserException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {

--- a/src/api/org.ts
+++ b/src/api/org.ts
@@ -3,6 +3,7 @@ import {
     AddUserToOrgException,
     ChangeUserRoleInOrgException,
     CreateOrgException,
+    RateLimitedException,
     RemoveUserFromOrgException,
     RevokePendingOrgInviteException,
     UpdateOrgException,
@@ -23,6 +24,8 @@ export function fetchOrg(authUrl: URL, integrationApiKey: string, orgId: string)
     return httpRequest(authUrl, integrationApiKey, `${ORG_ENDPOINT_PATH}/${orgId}`, "GET").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 404) {
             return null
         } else if (httpResponse.statusCode === 426) {
@@ -42,6 +45,8 @@ export function fetchCustomRoleMappings(authUrl: URL, integrationApiKey: string)
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 426) {
                 throw new Error(
                     "Cannot use organizations unless B2B support is enabled. Enable it in your PropelAuth dashboard."
@@ -97,6 +102,8 @@ export function fetchPendingInvites(
     return httpRequest(authUrl, integrationApiKey, path, "GET").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 426) {
             throw new Error(
                 "Cannot use organizations unless B2B support is enabled. Enable it in your PropelAuth dashboard."
@@ -124,6 +131,8 @@ export function fetchSamlSpMetadata(
     return httpRequest(authUrl, integrationApiKey, path, "GET").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 426) {
             throw new Error(
                 "Cannot use organizations unless B2B support is enabled. Enable it in your PropelAuth dashboard."
@@ -167,6 +176,8 @@ export function fetchOrgByQuery(authUrl: URL, integrationApiKey: string, query: 
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 400) {
                 throw new Error("Invalid query " + httpResponse.response)
             } else if (httpResponse.statusCode === 426) {
@@ -257,6 +268,8 @@ export function createOrg(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 400) {
                 throw new CreateOrgException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -290,6 +303,8 @@ export function addUserToOrg(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 400) {
                 throw new AddUserToOrgException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -330,6 +345,8 @@ export function changeUserRoleInOrg(
     ).then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 400) {
             throw new ChangeUserRoleInOrgException(httpResponse.response)
         } else if (httpResponse.statusCode === 404) {
@@ -365,6 +382,8 @@ export function removeUserFromOrg(
     ).then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 400) {
             throw new RemoveUserFromOrgException(httpResponse.response)
         } else if (httpResponse.statusCode === 404) {
@@ -390,6 +409,8 @@ export function allowOrgToSetupSamlConnection(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -414,6 +435,8 @@ export function disallowOrgToSetupSamlConnection(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -452,6 +475,8 @@ export async function createOrgSamlConnectionLink(
     )
     if (response.statusCode === 401) {
         throw new Error("integrationApiKey is incorrect")
+    } else if (response.statusCode === 429) {
+        throw new RateLimitedException(response.response)
     } else if (response.statusCode === 404) {
         throw new Error("Org not found")
     } else if (response.statusCode && response.statusCode >= 400) {
@@ -498,6 +523,8 @@ export function setSamlIdpMetadata(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 400) {
                 throw new UpdateOrgException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -524,6 +551,8 @@ export function samlGoLive(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -577,6 +606,8 @@ export function updateOrg(
     ).then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 400) {
             throw new UpdateOrgException(httpResponse.response)
         } else if (httpResponse.statusCode === 404) {
@@ -606,6 +637,8 @@ export function subscribeOrgToRoleMapping(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 400) {
                 throw new UpdateOrgException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -628,6 +661,8 @@ export function deleteOrg(authUrl: URL, integrationApiKey: string, orgId: string
     return httpRequest(authUrl, integrationApiKey, `${ORG_ENDPOINT_PATH}/${orgId}`, "DELETE").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 404) {
             return false
         } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -661,6 +696,8 @@ export function revokePendingOrgInvite(
     ).then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 400) {
             throw new RevokePendingOrgInviteException(httpResponse.response)
         } else if (httpResponse.statusCode === 404) {
@@ -690,6 +727,8 @@ export function deleteSamlConnection(
     ).then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 400) {
             throw new RevokePendingOrgInviteException(httpResponse.response)
         } else if (httpResponse.statusCode === 404) {

--- a/src/api/tokenVerificationMetadata.ts
+++ b/src/api/tokenVerificationMetadata.ts
@@ -1,3 +1,4 @@
+import { RateLimitedException } from "../exceptions"
 import { httpRequest } from "../http"
 
 export type TokenVerificationMetadata = {
@@ -21,6 +22,8 @@ export function fetchTokenVerificationMetadata(
         if (httpResponse.statusCode === 401) {
             console.error("Your API key is incorrect")
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
             console.error(`Error fetching token verification metadata: ${httpResponse.statusCode}`)
             throw new Error("Unknown error when fetching token verification metadata")

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -329,9 +329,11 @@ export function resendEmailConfirmation(authUrl: URL, integrationApiKey: string,
         } else if (httpResponse.statusCode === 404) {
             return false
         } else if (httpResponse.statusCode === 429) {
-            const errorMessage = JSON.parse(httpResponse.response).user_facing_error;
-            if (!errorMessage) {
-                throw new RateLimitedException(httpResponse.response)
+            let errorMessage: string;
+            try {
+                errorMessage = JSON.parse(httpResponse.response).user_facing_error;
+            } catch (SyntaxError) {
+                errorMessage = httpResponse.response;
             }
             throw new RateLimitedException(errorMessage)
         } else if (httpResponse.statusCode === 400) {

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,6 +1,7 @@
 import {
     BadRequestException,
     CreateUserException,
+    RateLimitedException,
     UpdateUserEmailException,
     UpdateUserMetadataException,
     UpdateUserPasswordException,
@@ -61,6 +62,8 @@ export function fetchUserMetadataByQuery(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
                 return null
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -102,6 +105,8 @@ export function fetchUsersByQuery(
     return httpRequest(authUrl, integrationApiKey, `${ENDPOINT_PATH}/query?${q}`, "GET").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 400) {
             throw new Error("Invalid query " + httpResponse.response)
         } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -139,6 +144,8 @@ export function fetchUsersInOrg(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 400) {
                 throw new Error("Invalid query " + httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -170,6 +177,8 @@ export function fetchBatchUserMetadata(
     ).then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 400) {
             throw new Error("Bad request " + httpResponse.response)
         } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -222,6 +231,8 @@ export function createUser(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 400) {
                 throw new CreateUserException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -242,6 +253,8 @@ export function disableUser(authUrl: URL, integrationApiKey: string, userId: str
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -261,6 +274,8 @@ export function enableUser(authUrl: URL, integrationApiKey: string, userId: stri
     return httpRequest(authUrl, integrationApiKey, `${ENDPOINT_PATH}/${userId}/enable`, "POST").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 404) {
             return false
         } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -280,6 +295,8 @@ export function disableUser2fa(authUrl: URL, integrationApiKey: string, userId: 
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -312,7 +329,11 @@ export function resendEmailConfirmation(authUrl: URL, integrationApiKey: string,
         } else if (httpResponse.statusCode === 404) {
             return false
         } else if (httpResponse.statusCode === 429) {
-            throw new Error("Rate limited when resending email confirmation")
+            const errorMessage = JSON.parse(httpResponse.response).user_facing_error;
+            if (!errorMessage) {
+                throw new RateLimitedException(httpResponse.response)
+            }
+            throw new RateLimitedException(errorMessage)
         } else if (httpResponse.statusCode === 400) {
             throw new BadRequestException(httpResponse.response)
         } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -346,6 +367,8 @@ export function inviteUserToOrg(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 400) {
                 throw new BadRequestException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -368,6 +391,8 @@ export function logoutAllUserSessions(authUrl: URL, integrationApiKey: string, u
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -412,6 +437,8 @@ export function updateUserMetadata(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 400) {
                 throw new UpdateUserMetadataException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -453,6 +480,8 @@ export function updateUserEmail(
     ).then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 400) {
             throw new UpdateUserEmailException(httpResponse.response)
         } else if (httpResponse.statusCode === 404) {
@@ -493,6 +522,8 @@ export function updateUserPassword(
     ).then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 400) {
             throw new UpdateUserPasswordException(httpResponse.response)
         } else if (httpResponse.statusCode === 404) {
@@ -514,6 +545,8 @@ export function enableUserCanCreateOrgs(authUrl: URL, integrationApiKey: string,
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -534,6 +567,8 @@ export function disableUserCanCreateOrgs(authUrl: URL, integrationApiKey: string
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
+            } else if (httpResponse.statusCode === 429) {
+                throw new RateLimitedException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -558,6 +593,8 @@ export async function clearUserPassword(authUrl: URL, integrationApiKey: string,
     )
     if (httpResponse.statusCode === 401) {
         throw new Error("integrationApiKey is incorrect")
+    } else if (httpResponse.statusCode === 429) {
+        throw new RateLimitedException(httpResponse.response)
     } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
         throw new Error("Unknown error when clearing password")
     }
@@ -573,6 +610,8 @@ export function deleteUser(authUrl: URL, integrationApiKey: string, userId: stri
     return httpRequest(authUrl, integrationApiKey, `${ENDPOINT_PATH}/${userId}`, "DELETE").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
             throw new Error("integrationApiKey is incorrect")
+        } else if (httpResponse.statusCode === 429) {
+            throw new RateLimitedException(httpResponse.response)
         } else if (httpResponse.statusCode === 404) {
             return false
         } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -604,6 +643,8 @@ export async function fetchUserSignupQueryParams(
     )
     if (httpResponse.statusCode === 401) {
         throw new Error("integrationApiKey is incorrect")
+    } else if (httpResponse.statusCode === 429) {
+        throw new RateLimitedException(httpResponse.response)
     } else if (httpResponse.statusCode === 404) {
         return null
     } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -156,6 +156,12 @@ export class ApiKeyValidateRateLimitedException extends Error {
     }
 }
 
+export class RateLimitedException extends Error {
+    constructor(message: string) {
+        super(message);
+    }
+}
+
 export class ApiKeyDeleteException extends Error {
     readonly fieldToErrors: {[fieldName: string]: string[]};
     constructor(message: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export {
     AccessTokenCreationException,
     AddUserToOrgException,
     BadRequestException,
+    RateLimitedException,
     CreateOrgException,
     CreateUserException,
     ForbiddenException,


### PR DESCRIPTION
## After PR
**Bumps patch to 2.1.29.**


Currently, if a customer's BE hits a PropelAuth rate limit, this library converts the response into 
```
Error("Unknown error when ...")
```
After this change, these responses will instead be converted to 
```
RateLimitedException("Rate limited. Please wait X seconds before trying again.")
```
All `validate*ApiKey` methods perform additional parsing on the error body in the case of a 429 to distinguish between rate limits set by customers to be enforced on end-users (ie the recently added `ApiKeyValidateRateLimitedException`) and rate limits set and imposed by PropelAuth (ie the new `RateLimitException`).

## Test
1. Setup a local dev environment with a rate limit on the hostname of `5 request / 10 seconds` and a rate limit of `10 requests / 1 minute` on personal api keys. 
2. Ran an express example app w/ these changes yalc-chained in via propelauth/node.
3. Spammed an example app's BE api with w/ a personal api key.
4. validated the example app's responses could differentiate between when the PropelAuth rate limit was hit and and when the personal-api-key rate limit was hit. The detailed error message data was successfully parsed out in both cases.