### PR TITLE
move auth hostname into custom header

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/PropelAuth/node-apis"
     },
-    "version": "2.1.29",
+    "version": "2.1.30",
     "license": "MIT",
     "keywords": [
         "auth",

--- a/src/http.ts
+++ b/src/http.ts
@@ -6,7 +6,7 @@ export type HttpResponse = {
 }
 
 export function httpRequest(
-    authUrlOrigin: URL,
+    authUrl: URL,
     apiKey: string,
     path: string,
     method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH",
@@ -15,7 +15,7 @@ export function httpRequest(
     let headers: any = {
         Authorization: "Bearer " + apiKey,
         "Content-Type": "application/json",
-        "X-Propelauth-url": authUrlOrigin.hostname,
+        "X-Propelauth-url": authUrl.hostname,
     }
 
     return fetch(BACKEND_API_BASE_URL + path, {

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,3 +1,5 @@
+const BACKEND_API_BASE_URL = "https://propelauth-api.com";
+
 export type HttpResponse = {
     statusCode?: number
     response: string
@@ -13,9 +15,10 @@ export function httpRequest(
     let headers: any = {
         Authorization: "Bearer " + apiKey,
         "Content-Type": "application/json",
+        "X-Propelauth-url": authUrlOrigin.hostname,
     }
 
-    return fetch(authUrlOrigin.origin + path, {
+    return fetch(BACKEND_API_BASE_URL + path, {
         method,
         headers,
         body,


### PR DESCRIPTION
## Tests
Validated expected behavior using a simple example app that checks the user's logged in status and validates end-user api keys. Verified the new domain and headers are used in BE logs.